### PR TITLE
Add inline cell editing, fix edit cell focus

### DIFF
--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -31,6 +31,7 @@ export * from './table-filter-row';
 export * from './table-fixed-columns';
 export * from './table-group-row';
 export * from './table-header-row';
+export * from './table-inline-cell-editing';
 export * from './table-row-detail';
 export * from './table-selection';
 export * from './table-summary-row';

--- a/src/plugins/table-inline-cell-editing.js
+++ b/src/plugins/table-inline-cell-editing.js
@@ -1,0 +1,5 @@
+import { withComponents } from '@devexpress/dx-react-core';
+import { TableInlineCellEditing as TableInlineCellEditingBase } from '@devexpress/dx-react-grid';
+import { EditCell as Cell } from '../templates/table-edit/cell';
+
+export const TableInlineCellEditing = withComponents({ Cell })(TableInlineCellEditingBase);

--- a/src/templates/table-edit/cell.js
+++ b/src/templates/table-edit/cell.js
@@ -21,25 +21,41 @@ import { TableCell } from '../../grommet/TableCell';
 
 export const EditCell = ({
   column, value, onValueChange, style, children,
-  row, tableRow, tableColumn, editingEnabled, ...restProps
-}) => (
-  <TableCell
-    tableContext='cell-edit'
-    align={tableColumn && tableColumn.align}
-    style={style}
-    {...restProps}
-  >
-    {children || (
-    <TextInput
-      plain={true}
-      focusIndicator={true}
-      value={value || ''}
-      disabled={!editingEnabled}
-      onChange={e => onValueChange(e.target.value)}
-    />
+  row, tableRow, tableColumn, editingEnabled,
+  autoFocus, onBlur, onFocus, onKeyDown, ...restProps
+}) => {
+  const patchedChildren = children
+    ? React.cloneElement(children, {
+      autoFocus,
+      onBlur,
+      onFocus,
+      onKeyDown,
+    })
+    : children;
+
+  return (
+    <TableCell
+      tableContext='cell-edit'
+      align={tableColumn && tableColumn.align}
+      style={style}
+      {...restProps}
+    >
+      {patchedChildren || (
+        <TextInput
+          plain={true}
+          focusIndicator={true}
+          value={(value === undefined || value === null) ? '' : value}
+          disabled={!editingEnabled}
+          onChange={e => onValueChange(e.target.value)}
+          autoFocus={autoFocus}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          onKeyDown={onKeyDown}
+        />
       )}
-  </TableCell>
-);
+    </TableCell>
+  );
+};
 
 EditCell.propTypes = {
   column: PropTypes.object,
@@ -51,6 +67,10 @@ EditCell.propTypes = {
   style: PropTypes.object,
   editingEnabled: PropTypes.bool,
   children: PropTypes.node,
+  autoFocus: PropTypes.bool,
+  onBlur: PropTypes.func,
+  onFocus: PropTypes.func,
+  onKeyDown: PropTypes.func,
 };
 
 EditCell.defaultProps = {
@@ -62,4 +82,8 @@ EditCell.defaultProps = {
   style: null,
   children: undefined,
   editingEnabled: true,
+  autoFocus: false,
+  onBlur: () => {},
+  onFocus: () => {},
+  onKeyDown: () => {},
 };


### PR DESCRIPTION
Inline cell editing is available in other React implementations of the
dx grid, so this commit follows the model from the Material
implementation at
https://github.com/DevExpress/devextreme-reactive/blob/master/packages/dx-react-grid-material-ui/src/plugins/table-inline-cell-editing.jsx
Additionally, clicking into a cell to edit required two clicks, because
the focus / blur properties were not passed down into the EditCell, so
now those are properly inherited.