### PR TITLE
Fix Table Edit row focus, style warning

### DIFF
--- a/src/templates/table-edit/row.js
+++ b/src/templates/table-edit/row.js
@@ -20,30 +20,40 @@ import { findDOMNode } from 'react-dom';
 import { filterByFocusable } from 'grommet/utils/DOM';
 import { TableRow as GrommetTableRow } from '../../grommet/TableRow';
 
-export const TableEditRow = ({
-  children,
-  row, tableRow,
-  ...rest
-}) => (
-  <GrommetTableRow
-    tableContext='row-edit'
-    ref={(ref) => {
-        if (ref) {
-          let items = findDOMNode(ref).getElementsByTagName('*');
-          items = filterByFocusable(items);
-          const focusables = items.filter(item => (['button', 'a'].indexOf(item.localName) === -1 && !item.disabled));
-          if (focusables.length > 0) {
-            setTimeout(() => {
-              focusables[0].focus();
-            }, 0);
-          }
+export class TableEditRow extends React.Component {
+  constructor(props) {
+    super(props);
+    this.textInput = null;
+
+    this.focusFirstCell = (element) => {
+      // Focus the text input using the raw DOM API
+      if (element && this.textInput === null) {
+        this.textInput = element;
+        let items = findDOMNode(element).getElementsByTagName('*');
+        items = filterByFocusable(items);
+        const focusables = items.filter(item => (['button', 'a'].indexOf(item.localName) === -1 && !item.disabled));
+        if (focusables.length > 0) {
+          setTimeout(() => {
+            focusables[0].focus();
+          }, 0);
         }
-      }}
-    {...rest}
-  >
-    {children}
-  </GrommetTableRow>
-);
+      }
+    };
+  }
+
+  render() {
+    const { children, row, tableRow, ...rest } = this.props;
+    return (<GrommetTableRow
+      tableContext='row-edit'
+      ref={this.focusFirstCell}
+      {...rest}
+    >
+      {children}
+    </GrommetTableRow>
+    );
+  }
+}
+
 
 TableEditRow.propTypes = {
   children: PropTypes.node,

--- a/src/templates/table-group-cell/content.js
+++ b/src/templates/table-group-cell/content.js
@@ -31,7 +31,7 @@ export const Content = ({
   >
     <strong>
       {column.title || column.name}
-        :
+      :
       {' '}
     </strong>
     {children || String(row.value)}


### PR DESCRIPTION
When creating a new row, the focus improperly reverts back to the first
cell whenever a change is made.  You can see this at
http://grommet-nextjs.herokuapp.com/template/dx-grid/data-editing
Reproduction steps:
* Create a new row by pressing "New"
* Click into any cell that isn't the "Product", e.g. "Sale Amount"
* Enter one number, e.g "1"
* Focus will go straight to the "Product" cell