### PR TITLE
Update dx-react-grid dep for InlineCellEditing

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "pub": "pushd ./ && npm run build && cd dist && npm publish && popd"
   },
   "peerDependencies": {
-    "@devexpress/dx-react-core": ">= 1.10.3",
-    "@devexpress/dx-react-grid": ">= 1.10.3",
+    "@devexpress/dx-react-core": ">= 2.1.0",
+    "@devexpress/dx-react-grid": ">= 2.1.0",
     "grommet": ">= 2.2.1",
     "grommet-icons": ">= 4.1.0",
     "react": ">= 16.7.0",
@@ -45,8 +45,8 @@
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "@devexpress/dx-react-core": "^1.10.3",
-    "@devexpress/dx-react-grid": "^1.10.3",
+    "@devexpress/dx-react-core": "^2.1.0",
+    "@devexpress/dx-react-grid": "^2.1.0",
     "babel-cli": "^6.22.2",
     "babel-core": "^6.26.0",
     "babel-eslint": "^7.2.3",

--- a/src/plugins/table-column-resizing.js
+++ b/src/plugins/table-column-resizing.js
@@ -20,11 +20,12 @@ import { TableColumnResizing as TableColumnResizingBase } from '@devexpress/dx-r
 
 export class TableColumnResizing extends React.PureComponent {
   render() {
-    const { minColumnWidth, ...restProps } = this.props;
+    const { minColumnWidth, maxColumnWidth, ...restProps } = this.props;
     return (
       <TableColumnResizingBase
         {...restProps}
         minColumnWidth={minColumnWidth}
+        maxColumnWidth={maxColumnWidth}
       />
     );
   }
@@ -32,8 +33,10 @@ export class TableColumnResizing extends React.PureComponent {
 
 TableColumnResizing.propTypes = {
   minColumnWidth: PropTypes.number,
+  maxColumnWidth: PropTypes.number,
 };
 
 TableColumnResizing.defaultProps = {
   minColumnWidth: 40,
+  maxColumnWidth: Infinity,
 };


### PR DESCRIPTION
Currently, there is a problem if running this against a version of
dx-react-grid below 2.1.0, since InlineCellEditing wasn't available
then.  This brings the build back to a working state.

There is also an update for column resizing to propagate all properties
down correctly.